### PR TITLE
My feature branch

### DIFF
--- a/Pach_Hybrid_Control.cs
+++ b/Pach_Hybrid_Control.cs
@@ -4167,7 +4167,7 @@ namespace Pachyderm_Acoustic
                         settings.TFReference = tfReference[0];
                         settings.IsCalibrated = ReadBool("Is the transfer function magnitude calibrated? (y/n): ");
 
-                        enableSmoothing = ReadBool("Enable smoothing? (y/n): ");
+                        enableSmoothing = ReadBool("Enable smoothing? (y/n): "); // It should be noted that this refers to smoothing of the EQ curve, not the input data.
                         settings.SmoothingOct = enableSmoothing
                             ? ReadClampedDouble("Enter smoothing octave fraction (e.g., 0.33): ", 0.05, 2.0)
                             : null;
@@ -4269,7 +4269,6 @@ namespace Pachyderm_Acoustic
                     }
                     else
                     {
-                        // Covers Nothing (Enter) and Cancel (Esc)
                         Rhino.RhinoApp.WriteLine("Invalid input. Please choose Yes or No.");
                     }
                 }

--- a/Pachyderm_Acoustic.csproj
+++ b/Pachyderm_Acoustic.csproj
@@ -1,87 +1,92 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net48;net7.0</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetExt>.rhp</TargetExt>
-    <!--<UseWPF>false</UseWPF>-->
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <WarningLevel>0</WarningLevel>
-    <RegisterForComInterop>false</RegisterForComInterop>
-  </PropertyGroup>
-  <PropertyGroup>
-    <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <RegisterForComInterop>false</RegisterForComInterop>
-    <RunCodeAnalysis>false</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>ExtendedDesignGuidelineRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-    <Version>$(VersionPrefix)</Version>
-    <Authors>Open Research in Acoustical Science and Education, Inc.</Authors>
-    <PackageProjectUrl>http://www.orase.org/</PackageProjectUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageLicenseFile>General_Public_License.txt</PackageLicenseFile>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>2.6.0.25</AssemblyVersion>
-    <FileVersion>2.6.0.25</FileVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <CodeAnalysisRuleSet>ExtendedDesignGuidelineRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="packages\**" />
-    <EmbeddedResource Remove="packages\**" />
-    <None Remove="packages\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="Pach_Absorption_Designer.Designer-PachydermMarch.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Eto">
-      <HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\Eto.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Rhino.UI">
-      <HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\Rhino.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RhinoCommon">
-      <HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\RhinoCommon.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <!--<Reference Update="System.Core">
+	<PropertyGroup>
+		<TargetFrameworks>net48;net7.0</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<IsWebBootstrapper>false</IsWebBootstrapper>
+		<PublishUrl>publish\</PublishUrl>
+		<Install>true</Install>
+		<InstallFrom>Disk</InstallFrom>
+		<UpdateEnabled>false</UpdateEnabled>
+		<UpdateMode>Foreground</UpdateMode>
+		<UpdateInterval>7</UpdateInterval>
+		<UpdateIntervalUnits>Days</UpdateIntervalUnits>
+		<UpdatePeriodically>false</UpdatePeriodically>
+		<UpdateRequired>false</UpdateRequired>
+		<MapFileExtensions>true</MapFileExtensions>
+		<ApplicationRevision>0</ApplicationRevision>
+		<ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+		<UseApplicationTrust>false</UseApplicationTrust>
+		<BootstrapperEnabled>true</BootstrapperEnabled>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<TargetExt>.rhp</TargetExt>
+		<!--<UseWPF>false</UseWPF>-->
+		<!--ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>-->
+		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<WarningLevel>0</WarningLevel>
+		<RegisterForComInterop>false</RegisterForComInterop>
+	</PropertyGroup>
+	<PropertyGroup>
+		<EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<RegisterForComInterop>false</RegisterForComInterop>
+		<RunCodeAnalysis>false</RunCodeAnalysis>
+		<CodeAnalysisRuleSet>ExtendedDesignGuidelineRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<PropertyGroup>
+		<StartupObject />
+		<Version>$(VersionPrefix)</Version>
+		<Authors>Open Research in Acoustical Science and Education, Inc.</Authors>
+		<PackageProjectUrl>http://www.orase.org/</PackageProjectUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseFile>General_Public_License.txt</PackageLicenseFile>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<AssemblyVersion>2.6.0.20</AssemblyVersion>
+		<FileVersion>2.6.0.20</FileVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+		<OutputPath>bin\x64\Debug\</OutputPath>
+		<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+		<OutputPath>bin\x64\Release\</OutputPath>
+		<CodeAnalysisRuleSet>ExtendedDesignGuidelineRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="packages\**" />
+		<EmbeddedResource Remove="packages\**" />
+		<None Remove="packages\**" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Remove="Pach_Absorption_Designer.Designer-PachydermMarch.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<Reference Include="Eto">
+			<HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\Eto.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="Rhino.UI">
+			<HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\Rhino.UI.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="RhinoCommon">
+			<HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\RhinoCommon.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="CLF_Read">
+			<HintPath>..\PachydermAcoustic_Universal\Pachyderm_Acoustic_Universal\Resources\CLF_Read.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+		<!--<Reference Update="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Update="UIAutomationProvider">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>-->
-  <!--</ItemGroup>-->
-  <!--<ItemGroup>
+		<!--</ItemGroup>-->
+		<!--<ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
       <Visible>False</Visible>
       <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
@@ -108,50 +113,55 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>-->
-  <!--<ItemGroup>-->
-    <Content Include="Resources\Icon1.png" />
-    <Content Include="Resources\Logo1Splash2.png" />
-    <Content Include="Resources\LogoOSplash.png" />
-    <Content Include="Resources\Source.bmp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CLF_Read_v2.n7\CLF_Read\CLF_Read.csproj" />
-    <ProjectReference Include="..\Hare\Hare.csproj">
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\PachydermAcoustic_Core\Pachyderm_Acoustic_Universal\Pachyderm_Acoustic_Universal\Pachyderm_Acoustic_Universal.csproj">
-      <Private>True</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\ScottPlot\src\ScottPlot5\ScottPlot5 Controls\ScottPlot.Eto\ScottPlot.Eto.csproj" />
-    <ProjectReference Include="..\ScottPlot\src\ScottPlot5\ScottPlot5\ScottPlot.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--<PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
+		<!--<ItemGroup>-->
+		<Content Include="Resources\**\*" CopyToOutputDirectory="PreserveNewest" />
+		<Content Include="misc\**\*" CopyToOutputDirectory="PreserveNewest" />
+
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Hare\Hare.csproj">
+			<Private>True</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\PachydermAcoustic_Universal\Pachyderm_Acoustic_Universal\Pachyderm_Acoustic_Universal.csproj">
+			<Private>True</Private>
+		</ProjectReference>
+		<ProjectReference Include="..\ScottPlot\src\ScottPlot5\ScottPlot5 Controls\ScottPlot.Eto\ScottPlot.Eto.csproj" />
+		<ProjectReference Include="..\ScottPlot\src\ScottPlot5\ScottPlot5\ScottPlot.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<!--<PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />-->
-    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="NetCoreAudio">
-      <Version>2.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Windows.Extensions">
-      <Version>7.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="General_Public_License.txt">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-  <!--<PropertyGroup>
+		<PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+		<PackageReference Include="NAudio" Version="2.2.1" />
+		<PackageReference Include="System.DirectoryServices" Version="8.0.0" />
+		<PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+		<PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
+		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.9" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="NetCoreAudio">
+			<Version>2.0.0</Version>
+		</PackageReference>
+		<PackageReference Include="System.Windows.Extensions">
+			<Version>7.0.0</Version>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="General_Public_License.txt">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
+	<!--<PropertyGroup>
     <PostBuildEvent>Copy "$(TargetPath)" "$(TargetDir)$(ProjectName).rhp"
 Copy "$(ProjectDir)Resources\libfftw3-3.dll" "$(TargetDir)"</PostBuildEvent>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>-->
+	<PropertyGroup>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## Edits

### Pach_Hybrid_Control.cs

- Added early and late IACC calculations (not benchmarked) using an FFT-based implementation of the ISO definition (see 3382-1 Annex B). Also included a reference SOFA dataset (KEMAR) for this - many thanks to Kanji Watanabe for confirming that we may bundle this dataset for educational use.
- Added CLI prompts for measurement system equalisation
- Update_Graph Auralisation view has been improved for clearer colour separation of stereo signals (from red and red-orange to blue and orange)
- We should add the ability to 'solo' individual signals in the auralisation graph (already a channels box in which we can do this) to reduce cluttering, especially for higher-order ambisonics

---

### .csproj files (both repos)
- I am terribly sorry for the mess I have been forced to make with this. I think this is always going to be a highly system-specific thing. Probably best to reject my changes, then manually add any references. Try running it from there. However, I am sure that as I have edited it, it will not run as intended on your machine.