### PR TITLE
HRTF GUI simplifications and improved state logic

### DIFF
--- a/PachHRTFOptions.cs
+++ b/PachHRTFOptions.cs
@@ -17,7 +17,6 @@ namespace Pachyderm_Acoustic.UI
     public sealed class HrtfCompensationOptions
     {
         public bool InputIsDTF { get; set; }
-        public bool ConvertToDTF { get; set; }
         public RhinoSystemCompSettings.EQType SelectedEQ { get; set; }
 
         public string MeasurementReferencePath { get; set; }
@@ -31,15 +30,11 @@ namespace Pachyderm_Acoustic.UI
 
         public Pachyderm_Acoustic.Audio.SystemResponseCompensation.SystemCompensationSettings ToPrimitiveSettings()
         {
-            var primitive = new Pachyderm_Acoustic.Audio.SystemResponseCompensation.SystemCompensationSettings
-            {
-                InputIsDTF = InputIsDTF
-            };
+            var primitive = new Pachyderm_Acoustic.Audio.SystemResponseCompensation.SystemCompensationSettings();
 
             if (InputIsDTF)
             {
                 primitive.SelectedEQ = (int)RhinoSystemCompSettings.EQType.None;
-                primitive.ConvertToDTF = false;
                 primitive.SmoothingOct = null;
                 primitive.MaxBoostDb = null;
                 primitive.LowFreqHz = null;
@@ -50,7 +45,6 @@ namespace Pachyderm_Acoustic.UI
                 return primitive;
             }
 
-            primitive.ConvertToDTF = ConvertToDTF;
             primitive.SelectedEQ = (int)SelectedEQ;
             primitive.SmoothingOct = SmoothingOct;
             primitive.MaxBoostDb = MaxBoostDb;
@@ -101,7 +95,6 @@ namespace Pachyderm_Acoustic.UI
         private Button _browseSofaButton;
 
         private DropDown _inputTypeDrop;
-        private CheckBox _convertToDtf;
         private DropDown _eqTypeDrop;
         private Label _eqNote;
 
@@ -181,7 +174,6 @@ namespace Pachyderm_Acoustic.UI
             return new HrtfCompensationOptions
             {
                 InputIsDTF = false,
-                ConvertToDTF = false,
                 SelectedEQ = RhinoSystemCompSettings.EQType.None,
                 FreeFieldIncidence = 30
             };
@@ -198,13 +190,6 @@ namespace Pachyderm_Acoustic.UI
             _inputTypeDrop.Items.Add("Directional-only / DTF");
             _inputTypeDrop.SelectedIndex = c.InputIsDTF ? 1 : 0;
             _inputTypeDrop.SelectedIndexChanged += delegate { UpdateUiState(); };
-
-            _convertToDtf = new CheckBox
-            {
-                Text = "Convert full HRTF to DTF",
-                Checked = c.ConvertToDTF
-            };
-            _convertToDtf.CheckedChanged += delegate { UpdateUiState(); };
 
             _eqTypeDrop = new DropDown();
             _eqTypeDrop.Items.Add("None");
@@ -358,7 +343,6 @@ namespace Pachyderm_Acoustic.UI
             layout.Spacing = new Size(8, 8);
 
             layout.AddRow(new Label { Text = "Input interpretation", Width = 180 }, _inputTypeDrop);
-            layout.AddRow(_convertToDtf, null);
             layout.AddRow(new Label { Text = "Equalisation", Width = 180 }, _eqTypeDrop);
             layout.AddRow(_eqNote);
             layout.AddRow(_measurementPanel);
@@ -367,7 +351,7 @@ namespace Pachyderm_Acoustic.UI
 
             return new GroupBox
             {
-                Text = "Input / Equalisation / DTF Processing",
+                Text = "Input / Equalisation Processing",
                 Content = layout
             };
         }
@@ -375,10 +359,8 @@ namespace Pachyderm_Acoustic.UI
         private void UpdateUiState()
         {
             bool inputIsDtf = _inputTypeDrop.SelectedIndex == 1;
-            bool convertToDtf = _convertToDtf.Checked == true;
             RhinoSystemCompSettings.EQType eq = GetSelectedEqType();
 
-            _convertToDtf.Enabled = !inputIsDtf;
             _eqTypeDrop.Enabled = !inputIsDtf;
 
             if (inputIsDtf)
@@ -386,7 +368,7 @@ namespace Pachyderm_Acoustic.UI
                 _measurementPanel.Visible = false;
                 _freeFieldPanel.Visible = false;
                 _diffuseFieldPanel.Visible = false;
-                _eqNote.Text = "Directional-only / DTF input bypasses HRTF-to-DTF conversion and equalisation setup.";
+                _eqNote.Text = "Directional-only / DTF input bypasses equalisation setup.";
             }
             else
             {
@@ -394,9 +376,7 @@ namespace Pachyderm_Acoustic.UI
                 _freeFieldPanel.Visible = eq == RhinoSystemCompSettings.EQType.FreeField;
                 _diffuseFieldPanel.Visible = eq == RhinoSystemCompSettings.EQType.DiffuseField;
 
-                _eqNote.Text = (convertToDtf && eq == RhinoSystemCompSettings.EQType.None)
-                    ? "Equalisation is required when converting a full HRTF to DTF."
-                    : string.Empty;
+                _eqNote.Text = string.Empty;
             }
 
             _measurementSmoothing.Enabled = _measurementUseSmoothing.Checked == true;
@@ -419,18 +399,11 @@ namespace Pachyderm_Acoustic.UI
         private HrtfCompensationOptions BuildCompensationOptions()
         {
             bool inputIsDtf = _inputTypeDrop.SelectedIndex == 1;
-            bool convertToDtf = !inputIsDtf && _convertToDtf.Checked == true;
             RhinoSystemCompSettings.EQType eq = inputIsDtf ? RhinoSystemCompSettings.EQType.None : GetSelectedEqType();
-
-            if (convertToDtf && eq == RhinoSystemCompSettings.EQType.None)
-            {
-                throw new InvalidOperationException("Choose Measurement, Free-field, or Diffuse-field equalisation when converting a full HRTF to DTF.");
-            }
 
             var c = new HrtfCompensationOptions
             {
                 InputIsDTF = inputIsDtf,
-                ConvertToDTF = convertToDtf,
                 SelectedEQ = eq
             };
 

--- a/Pach_Hybrid_Control.cs
+++ b/Pach_Hybrid_Control.cs
@@ -4086,67 +4086,6 @@ namespace Pachyderm_Acoustic
 
             private Pachyderm_Acoustic.Audio.SystemResponseCompensation.SystemCompensationSettings _sysCompSettingsPrimitives;
 
-            //public static Pachyderm_Acoustic.Audio.SystemResponseCompensation.SystemCompensationSettings GetSystemCompSettingsPrimitives()
-            //{
-            //    var rhinoSettings = GetRhinoSystemCompSettings();
-
-            //    return new Pachyderm_Acoustic.Audio.SystemResponseCompensation.SystemCompensationSettings
-            //    {
-            //        SelectedEQ = (int)rhinoSettings.SelectedEQ,
-            //        SmoothingOct = rhinoSettings.SmoothingOct,
-            //        MaxBoostDb = rhinoSettings.MaxBoostDb,
-            //        LowFreqHz = rhinoSettings.LowFreqHz,
-            //        MinPhase = rhinoSettings.MinPhase,
-            //        IsCalibrated = rhinoSettings.IsCalibrated,
-            //        TFReference = rhinoSettings.TFReference,
-            //        ConvertToDTF = rhinoSettings.ConvertToDTF,
-            //        InputIsDTF = rhinoSettings.InputIsDTF,
-            //        FreeFieldIncidence = rhinoSettings.FreeFieldIncidence
-            //    };
-            //}
-
-            //public static RhinoSystemCompSettings GetRhinoSystemCompSettings()
-            //{
-            //    var settings = new RhinoSystemCompSettings();
-
-            //    Rhino.RhinoApp.WriteLine("How should the input dataset be interpreted?");
-            //    Rhino.RhinoApp.WriteLine("1 = Raw HRTF");
-            //    Rhino.RhinoApp.WriteLine("2 = Reconstructed");
-
-            //    int inputType = ReadIntInRange("Choice: ", 1, 2);
-            //    settings.InputIsDTF = (inputType == 2);
-
-            //    if (settings.InputIsDTF) return settings;
-                
-            //    settings.ConvertToDTF = ReadBool("Do you want to convert this HRTF to a Constructed Directional Transfer Function? (y/n): ");
-
-            //    Rhino.RhinoApp.WriteLine("Equalisation compensates for the response of the measurement system.");
-            //    Rhino.RhinoApp.WriteLine("Select type:");
-
-            //    if (settings.ConvertToDTF)
-            //    {
-            //        // If converting to DTF, user must choose an EQ style (No EQ not allowed)
-            //        Rhino.RhinoApp.WriteLine("1 = Measurement Equalisation");
-            //        Rhino.RhinoApp.WriteLine("2 = Free-Field Equalisation");
-            //        Rhino.RhinoApp.WriteLine("3 = Diffuse-Field Equalisation");
-
-            //        int choice = ReadIntInRange("Choice: ", 1, 3);
-            //        AssignEQSettings(settings, choice);
-            //    }
-            //    else
-            //    {
-            //        Rhino.RhinoApp.WriteLine("1 = Measurement Equalisation");
-            //        Rhino.RhinoApp.WriteLine("2 = Free-Field Equalisation");
-            //        Rhino.RhinoApp.WriteLine("3 = Diffuse-Field Equalisation");
-            //        Rhino.RhinoApp.WriteLine("4 = No equalisation");
-
-            //        int choice = ReadIntInRange("Choice: ", 1, 4);
-            //        AssignEQSettings(settings, choice);
-            //    }
-
-            //    return settings;
-            //}
-
             private static void AssignEQSettings(RhinoSystemCompSettings settings, int choice)
             {
                 bool enableSmoothing;
@@ -4525,8 +4464,6 @@ namespace Pachyderm_Acoustic
 
                         if (_sysCompSettingsPrimitives != null)
                         {
-                            seed.InputIsDTF = _sysCompSettingsPrimitives.InputIsDTF;
-                            seed.ConvertToDTF = _sysCompSettingsPrimitives.ConvertToDTF;
                             seed.SelectedEQ = (RhinoSystemCompSettings.EQType)_sysCompSettingsPrimitives.SelectedEQ;
                             seed.SmoothingOct = _sysCompSettingsPrimitives.SmoothingOct;
                             seed.MaxBoostDb = _sysCompSettingsPrimitives.MaxBoostDb;
@@ -5450,8 +5387,6 @@ namespace Pachyderm_Acoustic
             public bool MinPhase { get; set; }
             public bool IsCalibrated { get; set; }
             public double[] TFReference { get; set; }
-            public bool ConvertToDTF { get; set; }
-            public bool InputIsDTF { get; set; }
             public int FreeFieldIncidence { get; set; }
         }
     }

--- a/Pachyderm_Acoustic.csproj
+++ b/Pachyderm_Acoustic.csproj
@@ -75,6 +75,9 @@
 			<HintPath>..\..\..\..\..\..\Program Files\Rhino 8\System\RhinoCommon.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="CLF_Read">
+			<HintPath>..\PachydermAcoustic_Core\Pachyderm_Acoustic_Universal\Pachyderm_Acoustic_Universal\Resources\CLF_Read.dll</HintPath>
+		</Reference>
 		<!--<Reference Update="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -115,7 +118,6 @@
 
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\CLF_Read_v2.n7\CLF_Read\CLF_Read.csproj" />
 		<ProjectReference Include="..\Hare\Hare.csproj">
 			<Private>True</Private>
 		</ProjectReference>

--- a/Pachyderm_Acoustic.sln
+++ b/Pachyderm_Acoustic.sln
@@ -1,9 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37012.4 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pachyderm_Acoustic", "Pachyderm_Acoustic.csproj", "{3EE4FD69-312E-479C-B4E7-E807F711F7EA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScottPlot", "..\ScottPlot\src\ScottPlot5\ScottPlot5\ScottPlot.csproj", "{11957613-DC8D-C4A9-438F-C0F24935D75C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hare", "..\Hare\Hare.csproj", "{7DDF9BFD-B5C8-D94F-87AC-88BF0F5B4C76}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScottPlot.Eto", "..\ScottPlot\src\ScottPlot5\ScottPlot5 Controls\ScottPlot.Eto\ScottPlot.Eto.csproj", "{864C2104-CD14-556B-6AED-22D7BB0C8FE5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pachyderm_Acoustic_Universal", "..\PachydermAcoustic_Core\Pachyderm_Acoustic_Universal\Pachyderm_Acoustic_Universal\Pachyderm_Acoustic_Universal.csproj", "{5D18DE4E-5829-49B8-2387-881A28474D76}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +23,27 @@ Global
 		{3EE4FD69-312E-479C-B4E7-E807F711F7EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EE4FD69-312E-479C-B4E7-E807F711F7EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EE4FD69-312E-479C-B4E7-E807F711F7EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11957613-DC8D-C4A9-438F-C0F24935D75C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11957613-DC8D-C4A9-438F-C0F24935D75C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11957613-DC8D-C4A9-438F-C0F24935D75C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11957613-DC8D-C4A9-438F-C0F24935D75C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DDF9BFD-B5C8-D94F-87AC-88BF0F5B4C76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DDF9BFD-B5C8-D94F-87AC-88BF0F5B4C76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DDF9BFD-B5C8-D94F-87AC-88BF0F5B4C76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DDF9BFD-B5C8-D94F-87AC-88BF0F5B4C76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{864C2104-CD14-556B-6AED-22D7BB0C8FE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{864C2104-CD14-556B-6AED-22D7BB0C8FE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{864C2104-CD14-556B-6AED-22D7BB0C8FE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{864C2104-CD14-556B-6AED-22D7BB0C8FE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D18DE4E-5829-49B8-2387-881A28474D76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D18DE4E-5829-49B8-2387-881A28474D76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D18DE4E-5829-49B8-2387-881A28474D76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D18DE4E-5829-49B8-2387-881A28474D76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E64769C5-B554-4F33-9CEE-9B48F034D4A2}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Removed the 'Convert full HRTF to DTF' checkbox and associated state-handling logic
- Removed ConvertToDTF and InputIsDTF from the RhinoSystemCompSettings wrapper class
- Updated the HrtfCompensationOptions.ToPrimitiveSettings() method so it no longer passes InputIsDTF or ConvertToDTF downstream
- The UI now directly handles 'Directional-only / DTF' input, bypassing the equalisation setup

All these steps do is just align our processing with my better understanding now of the equivalence of a DTF and a diffuse-field equalised HRTF